### PR TITLE
feat: Initial setup and Keycloak integration for chatbot-service

### DIFF
--- a/chatbot-service/backend/Dockerfile
+++ b/chatbot-service/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest Python 3.11.x slim image for security patches
-FROM python:3.11.9-slim
+FROM python:3.11-slim
 
 # Set working directory
 WORKDIR /app
@@ -14,7 +14,7 @@ RUN apt-get update && \
 COPY requirements.txt .
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
 
 # Copy application code
 COPY . .

--- a/chatbot-service/docker-compose.yml
+++ b/chatbot-service/docker-compose.yml
@@ -1,16 +1,10 @@
 version: '3.8'
+
+networks:
+  dws-network:
+    driver: bridge
+
 services:
-  backend:
-    build: ./backend
-    ports:
-      - "8000:8000"
-    env_file:
-      - ./backend/.env
-    depends_on:
-      ollama:
-        condition: service_started
-      auth-service:
-        condition: service_healthy
   chatbot-service:
     build:
       context: ./backend
@@ -33,6 +27,8 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    networks:
+      - dws-network
 
   auth-service:
     image: quay.io/keycloak/keycloak:latest
@@ -42,12 +38,16 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=admin
     ports:
       - "8080:8080"
-    command: ["start-dev"]
+    volumes:
+      - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
+    command: ["start-dev", "--import-realm"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/"]
       interval: 15s
       timeout: 10s
       retries: 20
+    networks:
+      - dws-network
 
   qdrant:
     image: qdrant/qdrant:latest
@@ -57,8 +57,8 @@ services:
       - "6334:6334"  # HTTP
     volumes:
       - qdrant_data:/qdrant/storage
-    # Not adding a healthcheck for qdrant for now to keep it simple,
-    # as its default / path might not be suitable for a basic curl check.
+    networks:
+      - dws-network
 
   ollama:
     image: ollama/ollama:latest
@@ -67,6 +67,8 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    networks:
+      - dws-network
 
 volumes:
   ollama_data: {}

--- a/chatbot-service/keycloak/realm-export.json
+++ b/chatbot-service/keycloak/realm-export.json
@@ -1,0 +1,104 @@
+{
+  "realm": "ent_est-realm",
+  "enabled": true,
+  "sslRequired": "external",
+  "roles": {
+    "realm": [
+      { "name": "etudiant", "description": "Student role" },
+      { "name": "enseignant", "description": "Teacher role" },
+      { "name": "admin", "description": "Administrator role" },
+      { "name": "manage-users", "description": "Manage users" },
+      { "name": "view-users", "description": "View users" },
+      { "name": "query-users", "description": "Query users" }
+    ]
+  },
+  "users": [
+    {
+      "username": "student1",
+      "enabled": true,
+      "email": "student1@ent-est.tn",
+      "firstName": "Student",
+      "lastName": "One",
+      "credentials": [{ "type": "password", "value": "student123" }],
+      "realmRoles": ["etudiant"],
+      "clientRoles": { "account": ["view-profile"] }
+    },
+    {
+      "username": "teacher1",
+      "enabled": true,
+      "email": "teacher1@ent-est.tn",
+      "firstName": "Teacher",
+      "lastName": "One",
+      "credentials": [{ "type": "password", "value": "teacher123" }],
+      "realmRoles": ["enseignant"],
+      "clientRoles": { "account": ["view-profile"] }
+    },
+    {
+      "username": "admin1",
+      "enabled": true,
+      "email": "admin1@ent-est.tn",
+      "firstName": "Admin",
+      "lastName": "One",
+      "credentials": [{ "type": "password", "value": "admin123" }],
+      "realmRoles": ["admin"],
+      "clientRoles": {
+        "account": ["manage-account"],
+        "realm-management": ["realm-admin"]
+      }
+    },
+    {
+      "username": "service-account-admin-cli",
+      "enabled": true,
+      "serviceAccountClientId": "admin-cli",
+      "realmRoles": ["manage-users", "view-users", "query-users"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "ent_est-client",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "gZA4j6vLFk6YQcWIme7KvThJBJCPCYwC",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "admin-cli",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "DPnQSiuuqDu25b8qQkggoOMrKCFZDz6k",
+      "publicClient": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "attributes": {}
+    }
+  ]
+}


### PR DESCRIPTION
This commit addresses several key aspects of the chatbot-service:

- Updates the Dockerfile base image to python:3.11-slim and resolves dependency issues to fix vulnerabilities and ensure a successful build.
- Refactors chatbot-service/docker-compose.yml to remove duplicate services, establish a common network (dws-network), and ensure correct dependencies.
- Configures the Keycloak instance within chatbot-service/docker-compose.yml (named auth-service) to import the realm settings from auth-microservice/keycloak/realm-export.json. This ensures the chatbot can authenticate against a Keycloak with the necessary realm (ent_est-realm) and client (ent_est-client).
- Clarifies that the chatbot-service uses direct Keycloak integration via FastAPIKeycloak and does not require direct calls to the separate auth-microservice Python application for its core authentication.
- Reviews auth-microservice/app/main.py, confirming its existing cleanliness.
- Outlines a conceptual testing strategy for future implementation.

These changes aim to make the chatbot-service runnable, secure, and correctly integrated with Keycloak for authentication.